### PR TITLE
feat: connect/desconnect wallet

### DIFF
--- a/src/components/Features/index.tsx
+++ b/src/components/Features/index.tsx
@@ -41,7 +41,7 @@ export const Features = () => {
   return (
     <section style={{
       position: "relative",
-      marginTop: "-85px",
+      marginTop: "-60px",
       padding: "0 20px",
       paddingBottom: "30px",
       zIndex: "10",

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -3,7 +3,6 @@ import React, { useState, useEffect, CSSProperties } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { LanguageSelector } from '../LanguageSelector';
-// No necesitamos importar ethers para esta funcionalidad
 
 export const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -106,6 +105,26 @@ export const Header = () => {
     }
   };
 
+  // Disconnect from MetaMask
+  const disconnectWallet = () => {
+    // En MetaMask no hay un método directo para "desconectar", pero podemos
+    // resetear nuestro estado para simular una desconexión
+    setIsConnected(false);
+    setUserAddress(null);
+    
+    // Informamos al usuario que se ha desconectado
+    alert(t('common.walletDisconnect'));
+  };
+
+  // Handle wallet button click based on connection state
+  const handleWalletButtonClick = () => {
+    if (isConnected) {
+      disconnectWallet();
+    } else {
+      connectWallet();
+    }
+  };
+
   // Format address for display
   const shortenAddress = (address: string) => {
     return `${address.slice(0, 6)}...${address.slice(-4)}`;
@@ -183,7 +202,7 @@ export const Header = () => {
     top: '64px',
     left: '0',
     right: '0',
-    backgroundColor: '#3f119b',
+    backgroundColor: '#362463',
     padding: '20px',
     display: isMenuOpen ? 'flex' : 'none',
     flexDirection: 'column',
@@ -244,13 +263,18 @@ export const Header = () => {
           <LanguageSelector />
           <button 
             style={isConnected ? connectedButtonStyle : buttonStyle}
-            onClick={connectWallet}
+            onClick={handleWalletButtonClick}
           >
             <span>
               {isConnected 
-                ? shortenAddress(userAddress || '') 
+                ? t('common.walletDisconnect') 
                 : t('common.connectWallet')}
             </span>
+            {isConnected && userAddress && (
+              <span style={{ marginLeft: '8px', fontSize: '14px' }}>
+                ({shortenAddress(userAddress)})
+              </span>
+            )}
           </button>
         </div>
 
@@ -277,24 +301,22 @@ export const Header = () => {
           <Link to="/results" style={linkStyle}>
             {t('common.seeResults')}
           </Link>
+          <LanguageSelector />
           <button 
             style={isConnected ? mobileConnectedButtonStyle : mobileButtonStyle}
-            onClick={connectWallet}
+            onClick={handleWalletButtonClick}
           >
             <span>
               {isConnected 
-                ? shortenAddress(userAddress || '') 
+                ? t('common.walletDisconnect') 
                 : t('common.connectWallet')}
             </span>
-            {!isConnected && (
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M12 4v16m8-8H4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-              </svg>
+            {isConnected && userAddress && (
+              <span style={{ marginLeft: '8px', fontSize: '14px' }}>
+                ({shortenAddress(userAddress)})
+              </span>
             )}
           </button>
-          <div style={mobileLangSelectorStyle}>
-            <LanguageSelector />
-          </div>
         </div>
       </nav>
     </header>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -6,6 +6,7 @@
       "createProposal": "Create Proposal",
       "seeResults": "See Voting Results",
       "connectWallet": "Connect Wallet",
+      "walletDisconnect": "Disconnect",     
       "loading": "Loading...",
       "error": "An error occurred",
       "invalidFileFormat": "Invalid file format",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -6,6 +6,7 @@
       "createProposal": "Crear Propuesta",
       "seeResults": "Ver Resultados",
       "connectWallet": "Conectar Wallet",
+      "walletDisconnect": "Desconectar",  
       "loading": "Cargando...",
       "error": "Ocurrió un error",
       "invalidFileFormat": "Formato de archivo no válido",


### PR DESCRIPTION
# Implemented Wallet Disconnect Functionality

This PR adds the capability to disconnect from MetaMask in the application's header component. Previously, once connected, users had no way to disconnect their wallet without manually doing so from the MetaMask extension.

## Changes implemented:

- Added a disconnect function in the Header component that resets the connection state
- Modified the wallet button to show "Disconnect" instead of the wallet address when connected
- Implemented proper display of the wallet address alongside the disconnect option for better user awareness
- Added event handling to toggle between connect and disconnect actions based on current connection state
- Implemented alert notifications to confirm when the wallet has been disconnected

## Additional improvements:

- Made minor styling adjustments to improve visual consistency
- Enhanced the button appearance to better indicate the current connection state
- Ensured proper responsiveness on both desktop and mobile layouts

These changes provide a more complete wallet management experience and align with standard Web3 UX patterns, giving users better control over their wallet connections within the application.

![image](https://github.com/user-attachments/assets/f38e9ad9-758d-45f7-b62e-977d201d8339)
![image](https://github.com/user-attachments/assets/c83811bb-1e04-4041-9e4f-b38fb5ace2ae)

