### PR TITLE
Add mobile MetaMask fallback

### DIFF
--- a/src/hooks/useWalletConnection.ts
+++ b/src/hooks/useWalletConnection.ts
@@ -31,7 +31,12 @@ export const useWalletConnection = () => {
   // Check current wallet state without requesting connection
   const checkWalletState = useCallback(async () => {
     if (!window.ethereum) {
-      setState(prev => ({ ...prev, error: "MetaMask is not installed", isConnected: false }));
+      const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+      setState(prev => ({
+        ...prev,
+        error: isMobile ? "Open in MetaMask to connect" : "MetaMask is not installed",
+        isConnected: false
+      }));
       return;
     }
 
@@ -157,7 +162,13 @@ export const useWalletConnection = () => {
 
   const connect = useCallback(async () => {
     if (!window.ethereum) {
-      setState(prev => ({ ...prev, error: "MetaMask is not installed" }));
+      const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+      if (isMobile) {
+        const dappUrl = encodeURIComponent(window.location.href);
+        window.location.href = `https://metamask.app.link/dapp/${dappUrl}`;
+      } else {
+        setState(prev => ({ ...prev, error: "MetaMask is not installed" }));
+      }
       return;
     }
 

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -18,6 +18,7 @@
       "votes": "Votes",
       "metamaskLogin": "Please login with Metamask to access the voting system.",
       "metamaskLoginShort": "Please login with Metamask...",
+      "openInMetamask": "Open this page in the MetaMask app to connect.",
       "download": "Install Zikuani",
       "connectedAs": "Connected As",
       "totalVotes": "Total Votes",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -18,6 +18,7 @@
       "votes": "Votos",
       "metamaskLogin": "Por favor, inicia sesión con Metamask para acceder al sistema de votación.",
       "metamaskLoginShort": "Por favor, inicia sesión con Metamask...",
+      "openInMetamask": "Abre esta página en la app de MetaMask para conectarte.",
       "download": "Instalar Zikuani",
       "connectedAs": "Conectado como",
       "totalVotes": "Votos Totales",

--- a/src/pages/Results.tsx
+++ b/src/pages/Results.tsx
@@ -156,7 +156,7 @@ const VoteResults: React.FC = () => {
                   error}
               </p>
               {(error === "Wallet no yet available." || !isConnected) && (
-                <button 
+                <button
                   onClick={connect}
                   style={{
                     backgroundColor: "#5856D6",
@@ -178,6 +178,11 @@ const VoteResults: React.FC = () => {
                 >
                   {t('common.connectWallet')}
                 </button>
+              )}
+              {error === "Open in MetaMask to connect" && (
+                <p style={{ marginTop: '15px', textAlign: 'center' }}>
+                  {t('common.openInMetamask')}
+                </p>
               )}
             </div>
           ) : (

--- a/src/pages/Vote.tsx
+++ b/src/pages/Vote.tsx
@@ -254,7 +254,7 @@ const Vote: React.FC = () => {
                 
                 {error === "Wallet no yet available." && (
                   <div style={{ marginTop: "15px", textAlign: "center" }}>
-                    <button 
+                    <button
                       onClick={connect}
                       style={{
                         backgroundColor: "#5856D6",
@@ -270,6 +270,9 @@ const Vote: React.FC = () => {
                       {t('common.connectWallet')}
                     </button>
                   </div>
+                )}
+                {error === "Open in MetaMask to connect" && (
+                  <p style={{ marginTop: "15px" }}>{t('common.openInMetamask')}</p>
                 )}
               </div>
             ) : loading ? (

--- a/src/pages/VoteValidation.tsx
+++ b/src/pages/VoteValidation.tsx
@@ -54,7 +54,12 @@ const VoteValidation: React.FC = () => {
       <h1>{t('voting.title')}</h1>
       <h2>{t('vc')}</h2>
       {error ? (
-        <p style={{ color: 'red' }}>{error}</p>
+        <div>
+          <p style={{ color: 'red' }}>{error}</p>
+          {error === "Open in MetaMask to connect" && (
+            <p>{t('common.openInMetamask')}</p>
+          )}
+        </div>
       ) : !loading && done && Object.keys(data).length > 0 ? (
         <VoteOptionsDisplay voteData={data} />
       ) : (


### PR DESCRIPTION
## Summary
- add detection for mobile wallets when no `window.ethereum` is present
- redirect mobile users to MetaMask via deep link
- show translated message when page must be opened in MetaMask

## Testing
- `yarn test --watchAll=false` *(fails: package not present in lockfile)*

